### PR TITLE
Add Gemini API key support and project description

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,14 @@
                      <div>
                         <label for="provider-selector" class="block text-sm font-medium text-gray-400">Provider</label>
                         <select id="provider-selector" class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+                            <option value="openai" selected>OpenAI</option>
                             <option value="gemini">Google Gemini</option>
-                            <option value="openai">OpenAI</option>
                             <option value="ollama">Ollama (Local)</option>
                         </select>
                      </div>
                      <div id="gemini-config" class="config-group space-y-2">
+                         <label for="gemini-api-key-input" class="block text-sm font-medium text-gray-400">API Key</label>
+                         <input type="password" id="gemini-api-key-input" placeholder="AIza..." class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
                          <label for="gemini-model-selector" class="block text-sm font-medium text-gray-400">Model</label>
                          <select id="gemini-model-selector" class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
                             <option value="gemini-1.5-flash-latest">gemini-1.5-flash-latest (Recommended)</option>
@@ -89,10 +91,15 @@
                 <h2 class="font-bold mb-2 text-white">4. System Prompt</h2>
                 <textarea id="system-prompt-input" rows="4" class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none">You are an AI assistant whose sole task is to process spreadsheet rows exactly as the user’s analysis tasks specify. Output only the requested content in the exact format required—no greetings, acknowledgments, or extra commentary.</textarea>
             </div>
-            
+
+            <div class="bg-gray-800 p-4 rounded-lg shadow-md">
+                <h2 class="font-bold mb-2 text-white">5. Project Description</h2>
+                <textarea id="project-description-input" rows="3" class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none" placeholder="Describe your research goals..."></textarea>
+            </div>
+
             <div class="bg-gray-800 p-4 rounded-lg shadow-md">
                  <div class="flex justify-between items-center mb-2">
-                    <h2 class="font-bold text-white">5. Analysis Pipeline</h2>
+                    <h2 class="font-bold text-white">6. Analysis Pipeline</h2>
                     <div class="relative" id="add-task-dropdown-container">
                         <button id="add-task-btn" class="bg-green-600 hover:bg-green-700 text-white font-bold py-1 px-3 rounded-md flex items-center">
                             Add Task <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
@@ -111,7 +118,7 @@
             </div>
 
             <div class="bg-gray-800 p-4 rounded-lg shadow-md">
-                <h2 class="font-bold mb-2 text-white">6. Estimate & Run 🔹</h2>
+                <h2 class="font-bold mb-2 text-white">7. Estimate & Run 🔹</h2>
                 <div class="bg-gray-900 p-3 rounded-lg text-center">
                     <p class="text-sm text-gray-400">Estimated Cost</p>
                     <p id="cost-estimate" class="text-2xl font-mono text-green-400">$0.00</p>

--- a/js/app.js
+++ b/js/app.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
         geminiConfig: document.getElementById('gemini-config'),
         openaiConfig: document.getElementById('openai-config'),
         ollamaConfig: document.getElementById('ollama-config'),
+        geminiApiKeyInput: document.getElementById('gemini-api-key-input'),
         geminiModelSelector: document.getElementById('gemini-model-selector'),
         openaiApiKeyInput: document.getElementById('openai-api-key-input'),
         fetchOpenAIModelsBtn: document.getElementById('fetch-openai-models-btn'),
@@ -20,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fetchOllamaModelsBtn: document.getElementById('fetch-ollama-models-btn'),
         ollamaModelSelector: document.getElementById('ollama-model-selector'),
         systemPromptInput: document.getElementById('system-prompt-input'),
+        projectDescriptionInput: document.getElementById('project-description-input'),
         addTaskDropdownContainer: document.getElementById('add-task-dropdown-container'),
         addTaskBtn: document.getElementById('add-task-btn'),
         addTaskMenu: document.getElementById('add-task-menu'),
@@ -187,7 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let totalInputTokens = 0;
         let totalOutputTokens = 0;
         const firstRow = appState.data[0];
-        const systemPromptTokens = estimateTokens(ui.systemPromptInput.value);
+        const systemPromptTokens = estimateTokens(ui.systemPromptInput.value + ui.projectDescriptionInput.value);
         
         appState.analysisTasks.forEach(task => {
             if (task.prompt && firstRow) {
@@ -222,10 +224,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     async function processWithGemini(userPrompt, systemPrompt, maxTokens) {
         const model = ui.geminiModelSelector.value;
-        const apiKey = "";
+        const apiKey = ui.geminiApiKeyInput.value;
         const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
-        const finalPrompt = `${systemPrompt}\n\n---\n\n${userPrompt}`;
-        const payload = { 
+        const projectDesc = ui.projectDescriptionInput.value;
+        const finalPrompt = `${systemPrompt}\n\nProject Description:\n${projectDesc}\n\n---\n\n${userPrompt}`;
+        const payload = {
             contents: [{ role: "user", parts: [{ text: finalPrompt }] }],
             generationConfig: {
                 maxOutputTokens: parseInt(maxTokens, 10) || 150,
@@ -240,12 +243,17 @@ document.addEventListener('DOMContentLoaded', () => {
     async function processWithOpenAI(userPrompt, systemPrompt, maxTokens) {
         const model = ui.openaiModelSelector.value;
         const apiKey = ui.openaiApiKeyInput.value;
+        const projectDesc = ui.projectDescriptionInput.value;
         if (!apiKey) throw new Error("OpenAI API Key is required.");
         if (!model) throw new Error("Please fetch and select an OpenAI model.");
         const apiUrl = `https://api.openai.com/v1/chat/completions`;
-        const payload = { 
-            model: model, 
-            messages: [{ role: "system", content: systemPrompt }, { role: "user", content: userPrompt }],
+        const payload = {
+            model: model,
+            messages: [
+                { role: "system", content: systemPrompt },
+                { role: "system", content: `Project Description:\n${projectDesc}` },
+                { role: "user", content: userPrompt }
+            ],
             max_tokens: parseInt(maxTokens, 10) || 150,
         };
         const response = await fetch(apiUrl, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` }, body: JSON.stringify(payload) });
@@ -259,10 +267,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const url = ui.ollamaUrlInput.value;
         if (!model) throw new Error("Please fetch and select an Ollama model.");
         const apiUrl = new URL('/api/generate', url).href;
-        const payload = { 
-            model: model, 
-            prompt: userPrompt, 
-            system: systemPrompt, 
+        const projectDesc = ui.projectDescriptionInput.value;
+        const payload = {
+            model: model,
+            prompt: `Project Description:\n${projectDesc}\n\n${userPrompt}`,
+            system: systemPrompt,
             stream: false,
             options: {
                 num_predict: parseInt(maxTokens, 10) || 150,
@@ -412,18 +421,37 @@ document.addEventListener('DOMContentLoaded', () => {
     
     async function autoGenerateTask() {
         if (appState.data.length === 0) { log('Upload a file before using Auto-Generate.', 'ERROR'); return; }
-        if (!confirm('This will use API resources to auto-generate a single bulk analysis task. Continue?')) return;
-        log('Generating auto task...', 'API');
+        if (!confirm('This will use API resources to auto-generate tasks for empty columns. Continue?')) return;
+        log('Generating auto tasks...', 'API');
+
         const headers = appState.headers;
+        const emptyCols = headers.filter(h => appState.data.every(r => !r[h]));
+        if (emptyCols.length === 0) { log('No empty columns detected.', 'ERROR'); return; }
+        const dataCols = headers.filter(h => !emptyCols.includes(h));
         const sampleRows = appState.data.slice(0,5);
         const preview = [headers.join(' | ')].concat(sampleRows.map(r => headers.map(h => r[h]).join(' | '))).join('\n');
-        const userPrompt = `Spreadsheet Preview:\n${preview}\n\nDescribe this spreadsheet in a couple sentences. Mention which columns have data and which are empty. Suggest analysis instructions to fill the empty columns based on existing data.`;
+        const projectDesc = ui.projectDescriptionInput.value || 'N/A';
+        const userPrompt = `Project Description: ${projectDesc}\nSpreadsheet Preview:\n${preview}\n\nExisting columns with data: ${dataCols.join(', ')}.\nColumns needing analysis: ${emptyCols.join(', ')}.\n\nFor each column needing analysis, provide one line in the form "Column -> instruction" describing how to analyze each row.`;
+
         try {
-            const result = await processWithApi(userPrompt, 200);
-            addAnalysisTask('auto', { prompt: result.text.trim() });
-            log('Auto-generated task added.', 'SUCCESS');
+            const result = await processWithApi(userPrompt, 400);
+            const lines = result.text.split(/\n+/).map(l => l.trim()).filter(Boolean);
+            let added = 0;
+            lines.forEach(line => {
+                const parts = line.split('->');
+                if (parts.length >= 2) {
+                    const col = parts[0].trim();
+                    const instr = parts.slice(1).join('->').trim();
+                    if (emptyCols.includes(col)) {
+                        addAnalysisTask('custom', { outputColumn: col, prompt: instr });
+                        added++;
+                    }
+                }
+            });
+            if (added > 0) log(`Auto-generated ${added} task(s).`, 'SUCCESS');
+            else log('Auto generation produced no usable tasks.', 'ERROR');
         } catch (error) {
-            log(`Failed to auto-generate task: ${error.message}`, 'ERROR');
+            log(`Failed to auto-generate tasks: ${error.message}`, 'ERROR');
         }
     }
     function startTestMode(task) {
@@ -480,6 +508,7 @@ document.addEventListener('DOMContentLoaded', () => {
             provider: ui.providerSelector.value,
             modelConfig: {},
             systemPrompt: ui.systemPromptInput.value,
+            projectDescription: ui.projectDescriptionInput.value,
             analysisTasks: appState.analysisTasks,
         };
 
@@ -495,6 +524,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 break;
              case 'gemini':
                 profile.modelConfig.model = ui.geminiModelSelector.value;
+                profile.modelConfig.apiKey = ui.geminiApiKeyInput.value;
                 break;
         }
         
@@ -520,6 +550,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 ui.providerSelector.dispatchEvent(new Event('change'));
 
                 ui.systemPromptInput.value = profile.systemPrompt || DEFAULT_SYSTEM_PROMPT;
+                ui.projectDescriptionInput.value = profile.projectDescription || '';
 
                 const { modelConfig } = profile;
                 if (modelConfig) {
@@ -540,6 +571,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             break;
                          case 'gemini':
                             ui.geminiModelSelector.value = modelConfig.model || 'gemini-1.5-flash-latest';
+                            ui.geminiApiKeyInput.value = modelConfig.apiKey || '';
                             break;
                     }
                 }
@@ -587,7 +619,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateCostEstimate();
     });
     
-    [ui.geminiModelSelector, ui.openaiModelSelector, ui.ollamaModelSelector, ui.systemPromptInput].forEach(el => el.addEventListener('input', updateCostEstimate));
+    [ui.geminiModelSelector, ui.openaiModelSelector, ui.ollamaModelSelector, ui.systemPromptInput, ui.projectDescriptionInput].forEach(el => el.addEventListener('input', updateCostEstimate));
     
     ui.fetchOpenAIModelsBtn.addEventListener('click', async () => {
         const apiKey = ui.openaiApiKeyInput.value;


### PR DESCRIPTION
## Summary
- integrate Gemini API key field and set OpenAI as default provider
- add project description input that is included with prompts
- update model calls to pass project description
- improve autogenerate to create per-column tasks for empty columns
- persist new fields in profiles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a9e02cf68832fb155bab040270916