### PR TITLE
Implement exportable audit log

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                     <h2 class="font-bold text-white">Audit Log</h2>
                     <div>
                          <button id="download-results-btn" class="text-sm bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-md hidden">Download CSV</button>
-                         <button id="download-log-btn" class="text-sm bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-md hidden">Download Log</button>
+                         <button id="download-log-btn" class="text-sm bg-gray-600 hover:bg-gray-500 text-white font-bold py-1 px-3 rounded-md" disabled>Download Log</button>
                     </div>
                 </div>
                 <div id="audit-log" class="flex-grow bg-gray-900 rounded-md p-2 text-xs font-mono overflow-y-auto border border-gray-700">


### PR DESCRIPTION
## Summary
- initialize runLog audit structure and display Download Log button from start
- track prompts and token usage for Gemini, OpenAI, and Ollama requests
- allow audit log download anytime
- show audit logging messages and enable button when entries exist

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ac2348ba4832faa3837d73055d0ba