### PR TITLE
Add validation checks and context toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
             <div class="bg-gray-800 p-4 rounded-lg shadow-md">
                 <h2 class="font-bold mb-2 text-white">4. System Prompt</h2>
                 <textarea id="system-prompt-input" rows="4" class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none">You are an AI assistant whose sole task is to process spreadsheet rows exactly as the user’s analysis tasks specify. Output only the requested content in the exact format required—no greetings, acknowledgments, or extra commentary.</textarea>
+                <label class="flex items-center text-sm mt-2"><input type="checkbox" id="include-row-context-toggle" class="mr-2" checked>Include full row context in prompt</label>
             </div>
 
             <div class="bg-gray-800 p-4 rounded-lg shadow-md">
@@ -147,6 +148,17 @@
                     <button id="run-btn" class="w-full bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-md flex items-center justify-center">Run</button>
                 </div>
                  <button id="test-mode-btn" class="mt-2 w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-md flex items-center justify-center">Test Mode</button>
+            </div>
+
+            <div class="bg-gray-800 p-4 rounded-lg shadow-md">
+                <h2 class="font-bold mb-2 text-white">9. Validation & Tests</h2>
+                <div class="space-y-2">
+                    <label class="flex items-center text-sm"><input type="checkbox" id="check-missing-outputs" class="mr-2">Report blank or invalid AI outputs</label>
+                    <label class="flex items-center text-sm"><input type="checkbox" id="prompt-stability" class="mr-2">Prompt stability test</label>
+                    <label class="flex items-center text-sm"><input type="checkbox" id="consistency-check" class="mr-2">Check logical consistency between columns</label>
+                    <select id="consistency-columns" multiple class="w-full bg-gray-700 border border-gray-600 rounded-md p-2 text-sm"></select>
+                    <label class="flex items-center text-sm"><input type="checkbox" id="face-validity" class="mr-2">Export side-by-side sample of human vs. AI outputs</label>
+                </div>
             </div>
         </div>
 
@@ -206,9 +218,15 @@
                 <textarea data-type="prompt" rows="4" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none" placeholder="Analyze the content of the selected column..."></textarea>
                 <p class="text-xs text-gray-500 mt-1">Variable `{{COLUMN}}` is replaced by the source column's value.<br>You can also reference any other column with `{{Column Name}}`.</p>
             </div>
-             <div>
-                <label class="block text-sm font-medium text-gray-400">4. Max Output Tokens</label>
-                <input type="number" data-type="maxTokens" value="150" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+            <div>
+               <label class="block text-sm font-medium text-gray-400">4. Max Output Tokens</label>
+               <input type="number" data-type="maxTokens" value="150" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
+            </div>
+            <div>
+                <label class="flex items-center text-sm"><input type="checkbox" data-type="reliabilityCheck" class="task-input mr-2">Compare output with human-coded column</label>
+                <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option>Select column...</option>
+                </select>
             </div>
         </div>
     </div>
@@ -226,7 +244,7 @@
                 <div class="source-columns-container space-y-2"></div>
                 <button class="add-source-column-btn mt-2 text-sm bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded-md">Add Column</button>
             </div>
-             <div class="grid grid-cols-2 gap-4">
+            <div class="grid grid-cols-2 gap-4">
                 <div>
                     <label class="block text-sm font-medium text-gray-400">2. Save Result To</label>
                     <input type="text" data-type="outputColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none" placeholder="e.g., comparison_result">
@@ -235,6 +253,12 @@
                     <label class="block text-sm font-medium text-gray-400">4. Max Output Tokens</label>
                     <input type="number" data-type="maxTokens" value="150" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
                 </div>
+            </div>
+            <div>
+                <label class="flex items-center text-sm"><input type="checkbox" data-type="reliabilityCheck" class="task-input mr-2">Compare output with human-coded column</label>
+                <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option>Select column...</option>
+                </select>
             </div>
             <div>
                 <div class="flex justify-between items-center">
@@ -258,7 +282,7 @@
             <button class="remove-task-btn text-gray-500 hover:text-red-400 text-xl leading-none">&times;</button>
         </div>
         <div class="space-y-3">
-             <div class="grid grid-cols-2 gap-4">
+            <div class="grid grid-cols-2 gap-4">
                 <div>
                     <label class="block text-sm font-medium text-gray-400">1. Save Result To</label>
                     <input type="text" data-type="outputColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none" placeholder="e.g., custom_output">
@@ -267,6 +291,12 @@
                     <label class="block text-sm font-medium text-gray-400">2. Max Output Tokens</label>
                     <input type="number" data-type="maxTokens" value="150" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
                 </div>
+            </div>
+            <div>
+                <label class="flex items-center text-sm"><input type="checkbox" data-type="reliabilityCheck" class="task-input mr-2">Compare output with human-coded column</label>
+                <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option>Select column...</option>
+                </select>
             </div>
             <div>
                 <div class="flex justify-between items-center">
@@ -299,6 +329,12 @@
                     <label class="block text-sm font-medium text-gray-400">2. Max Output Tokens</label>
                     <input type="number" data-type="maxTokens" value="150" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:outline-none">
                 </div>
+            </div>
+            <div>
+                <label class="flex items-center text-sm"><input type="checkbox" data-type="reliabilityCheck" class="task-input mr-2">Compare output with human-coded column</label>
+                <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option>Select column...</option>
+                </select>
             </div>
             <div>
                 <div class="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- add Include Row Context toggle for prompts
- add validation & testing section with various checks
- allow per-task human comparison for intercoder reliability
- compute reliability, consistency, missing outputs, face validity, and prompt stability
- store validation results in audit log

## Testing
- `node --check js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_687e8181dbac832fb1bc73bc197781d7