### PR TITLE
Add inline output analysis dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>Spreadsheet AI Processor</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/wordcloud2.js/1.1.0/wordcloud2.min.js"></script>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="bg-gray-900 text-gray-300 font-sans flex flex-col h-screen">
@@ -203,6 +205,11 @@
                 <div id="audit-log" class="flex-grow bg-gray-900 rounded-md p-2 text-xs font-mono overflow-y-auto border border-gray-700">
                     <p class="text-gray-500">[SYSTEM] Application initialized with multi-task pipeline. Waiting for user input.</p>
                 </div>
+            </div>
+            <div id="analysis-dashboard-panel" class="h-1/3 flex flex-col bg-gray-800 p-4 rounded-lg shadow-md hidden">
+                <h2 class="font-bold text-white">AI Output Analysis Dashboard</h2>
+                <p class="text-sm text-gray-400 mb-2">Explore results for each output column</p>
+                <div id="analysis-dashboard" class="flex-grow overflow-y-auto space-y-2"></div>
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- allow chart visualization of output columns
- include Chart.js and WordCloud libraries
- add collapsible panel showing AI Output Analysis Dashboard
- generate automatic charts and stats after running tasks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e8fb248d4832fbb491f4f42641e20