### PR TITLE
Add Krippendorff Alpha and dashboard override

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ An LLM-Enhanced Spreadsheet Classifier App that lets you upload a spreadsheet, d
   - Display charts:
     - Histogram (numeric)
     - Bar chart (categorical)
-    - Word cloud (text)
+  - Word cloud (text)
   - Export summary statistics and frequency tables
   - Log scale toggle for numeric data
+  - Manual override to treat columns as text or categorical
 
 ### 🔎 Validation Tools
-- Reliability Checks (Cohen's Kappa and exact match)
+- Reliability Checks (Cohen's Kappa, Krippendorff's Alpha, and exact match)
 - Consistency between columns (Pearson or pairwise)
 - Missing Output Audit
 - Prompt Stability Test (token-level diff)


### PR DESCRIPTION
## Summary
- update README with Krippendorff's alpha and dashboard override mention
- track dashboard type overrides in state
- add Krippendorff Alpha calculation
- expose alpha result alongside Cohen's kappa in validation log
- allow overriding column type in the analysis dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68811cd62d50832f9d02c5a43fc75b97