### PR TITLE
Add intercoder reliability dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ An LLM-Enhanced Spreadsheet Classifier App that lets you upload a spreadsheet, d
   - Manual override to treat columns as text or categorical
 
 ### 🔎 Validation Tools
-- Reliability Checks (Cohen's Kappa, Krippendorff's Alpha, and exact match)
+- Reliability Checks (Cohen's Kappa, Krippendorff's Alpha, and exact match) with a dedicated **Intercoder Reliability** dashboard section
 - Consistency between columns (Pearson or pairwise)
 - Missing Output Audit
 - Prompt Stability Test (token-level diff)

--- a/index.html
+++ b/index.html
@@ -225,6 +225,10 @@
                 <h2 class="font-bold text-white">AI Output Analysis Dashboard</h2>
                 <p class="text-sm text-gray-400 mb-2">Explore results for each output column</p>
                 <div id="analysis-dashboard" class="flex-grow overflow-y-auto space-y-2"></div>
+                <div id="reliability-panel" class="mt-4 hidden">
+                    <h3 class="font-bold text-white mb-2">Intercoder Reliability</h3>
+                    <div id="reliability-dashboard" class="space-y-2"></div>
+                </div>
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- show intercoder reliability results in a new dashboard section
- log Cohen's kappa and Krippendorff's alpha results to audit log

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68812276b9e4832fb5cff7fd8bb52c4d