### PR TITLE
Improve reliability options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ An LLM-Enhanced Spreadsheet Classifier App that lets you upload a spreadsheet, d
 - Krippendorff's Alpha supports multi-label coding by treating coder annotations as sets and calculating disagreement via Jaccard distance
 - Observed disagreement averages pairwise distances across units, while expected disagreement samples from the empirical distribution of code sets
 - Partial overlap earns a distance between 0 and 1, so partial agreement is rewarded more than total disagreement but less than a perfect match
+- Alpha weighting can be switched between **Basic** (binary match), **Jaccard**, or **MASI** distance
+- The reliability panel reports the observed disagreement ($D_o$) and expected disagreement ($D_e$) used in the alpha calculation
+- $\alpha = 1 - \frac{D_o}{D_e}$ where each distance function returns a value in $[0,1]$
 
 ### 🛠️ Model Configuration
 - Supports OpenAI, Gemini, and local Ollama models

--- a/index.html
+++ b/index.html
@@ -272,6 +272,11 @@
                 <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
                     <option>Select column...</option>
                 </select>
+                <select data-type="reliabilityMethod" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option value="jaccard">Alpha Weighted (Jaccard)</option>
+                    <option value="binary">Basic Alpha</option>
+                    <option value="masi">Alpha Weighted (MASI)</option>
+                </select>
             </div>
         </div>
     </div>
@@ -303,6 +308,11 @@
                 <label class="flex items-center text-sm"><input type="checkbox" data-type="reliabilityCheck" class="task-input mr-2">Compare output with human-coded column</label>
                 <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
                     <option>Select column...</option>
+                </select>
+                <select data-type="reliabilityMethod" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option value="jaccard">Alpha Weighted (Jaccard)</option>
+                    <option value="binary">Basic Alpha</option>
+                    <option value="masi">Alpha Weighted (MASI)</option>
                 </select>
             </div>
             <div>
@@ -342,6 +352,11 @@
                 <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
                     <option>Select column...</option>
                 </select>
+                <select data-type="reliabilityMethod" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option value="jaccard">Alpha Weighted (Jaccard)</option>
+                    <option value="binary">Basic Alpha</option>
+                    <option value="masi">Alpha Weighted (MASI)</option>
+                </select>
             </div>
             <div>
                 <div class="flex justify-between items-center">
@@ -379,6 +394,11 @@
                 <label class="flex items-center text-sm"><input type="checkbox" data-type="reliabilityCheck" class="task-input mr-2">Compare output with human-coded column</label>
                 <select data-type="reliabilityColumn" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
                     <option>Select column...</option>
+                </select>
+                <select data-type="reliabilityMethod" class="task-input w-full bg-gray-700 border border-gray-600 rounded-md p-2 mt-1" disabled>
+                    <option value="jaccard">Alpha Weighted (Jaccard)</option>
+                    <option value="binary">Basic Alpha</option>
+                    <option value="masi">Alpha Weighted (MASI)</option>
                 </select>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- allow choosing how to weight multi-label Krippendorff's Alpha
- show disagreement details in reliability reports
- document alpha weighting options

## Testing
- `node -c js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68812e36229c832f83badd1425a98e13