### PR TITLE
Improve panel layout and mobile behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,3 +30,16 @@
         .hidden-config, .hidden {
             display: none;
         }
+
+        /* Allow panels to be resized */
+        .resizable-y {
+            resize: vertical;
+            overflow: auto;
+            min-height: 4rem;
+        }
+
+        .resizable-x {
+            resize: horizontal;
+            overflow: auto;
+            min-width: 10rem;
+        }

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <main class="flex-grow flex p-4 gap-4 overflow-hidden">
 
         <!-- Left Panel: Controls -->
-        <div id="controls-panel" class="w-1/3 flex flex-col space-y-4 overflow-y-auto pr-2">
+        <div id="controls-panel" class="w-full md:w-1/3 flex flex-col space-y-4 overflow-y-auto pr-2 resizable-x">
             
             <div class="bg-gray-800 p-4 rounded-lg shadow-md">
                 <h2 class="font-bold mb-2 text-white">1. Profile Management</h2>
@@ -199,8 +199,8 @@
         </div>
 
         <!-- Right Panel: Data & Logs -->
-        <div class="w-2/3 flex flex-col space-y-4 overflow-hidden">
-            <div class="flex-grow flex flex-col bg-gray-800 p-4 rounded-lg shadow-md overflow-hidden">
+        <div id="right-panel" class="w-full md:w-2/3 flex flex-col space-y-4 overflow-y-auto resizable-x hidden md:flex">
+            <div class="flex-grow flex flex-col bg-gray-800 p-4 rounded-lg shadow-md overflow-y-auto resizable-y">
                 <h2 class="font-bold mb-2 text-white">Data Preview</h2>
                 <div id="data-preview" class="flex-grow overflow-auto border border-gray-700 rounded-lg">
                     <p class="p-4 text-gray-500">Upload a CSV file to see a preview of the data here.</p>
@@ -209,7 +209,7 @@
                     <div id="progress-bar" class="bg-blue-600 h-2.5 rounded-full" style="width: 0%"></div>
                 </div>
             </div>
-            <div class="h-1/3 flex flex-col bg-gray-800 p-4 rounded-lg shadow-md">
+            <div class="h-1/3 flex flex-col bg-gray-800 p-4 rounded-lg shadow-md resizable-y">
                 <div class="flex justify-between items-center mb-2">
                     <h2 class="font-bold text-white">Audit Log</h2>
                     <div>
@@ -221,7 +221,7 @@
                     <p class="text-gray-500">[SYSTEM] Application initialized with multi-task pipeline. Waiting for user input.</p>
                 </div>
             </div>
-            <div id="analysis-dashboard-panel" class="h-1/3 flex flex-col bg-gray-800 p-4 rounded-lg shadow-md hidden">
+            <div id="analysis-dashboard-panel" class="h-1/3 flex flex-col bg-gray-800 p-4 rounded-lg shadow-md hidden resizable-y">
                 <h2 class="font-bold text-white">AI Output Analysis Dashboard</h2>
                 <p class="text-sm text-gray-400 mb-2">Explore results for each output column</p>
                 <div id="analysis-dashboard" class="flex-grow overflow-y-auto space-y-2"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -98,6 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
         faceValidity: document.getElementById('face-validity'),
         analysisDashboardPanel: document.getElementById('analysis-dashboard-panel'),
         analysisDashboard: document.getElementById('analysis-dashboard'),
+        rightPanel: document.getElementById('right-panel'),
     };
 
     // --- State Management ---
@@ -1659,11 +1660,15 @@ document.addEventListener('DOMContentLoaded', () => {
         if (appState.isProcessing || appState.data.length === 0) { log('Cannot start run. No data loaded.', 'ERROR'); return; }
         if (appState.analysisTasks.length === 0) { log('Cannot start run. Please add at least one analysis task.', 'ERROR'); return; }
         for (const task of appState.analysisTasks) {
-            if (!task.outputColumn || !task.prompt || 
-               (task.type === 'analyze' && !task.sourceColumn) || 
+            if (!task.outputColumn || !task.prompt ||
+               (task.type === 'analyze' && !task.sourceColumn) ||
                (task.type === 'compare' && task.sourceColumns.some(sc => !sc))) {
                 log(`Task is incomplete. Please fill all fields for each task before running.`, 'ERROR'); return;
             }
+        }
+
+        if (window.innerWidth < 768) {
+            ui.rightPanel.classList.remove('hidden');
         }
         
         setProcessingState(true);


### PR DESCRIPTION
## Summary
- allow panels to be resized with new CSS classes
- update layout so right panel is scrollable
- hide data/log pane on mobile until run
- show pane on run click

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68825caf15a4832f8a253e6cf46364d2