### PR TITLE
Replace deprecated OpenAI token parameter

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -946,7 +946,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const payload = {
                 model,
                 input: finalPrompt,
-                max_completion_tokens: parseInt(maxTokens, 10) || parseInt(params.maxTokens,10) || 150,
+                max_output_tokens: parseInt(maxTokens, 10) || parseInt(params.maxTokens,10) || 150,
                 temperature: parseFloat(params.temperature),
                 reasoning: { effort: params.reasoning },
                 text: { verbosity: params.verbosity }


### PR DESCRIPTION
## Summary
- fix OpenAI Responses API usage by switching `max_completion_tokens` to `max_output_tokens`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b364897b8083299e3acc51d2064c89