### PR TITLE
Ensure Ollama URL includes scheme before fetching models

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1755,7 +1755,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     ui.fetchOllamaModelsBtn.addEventListener('click', async () => {
-        const url = ui.ollamaUrlInput.value;
+        let url = ui.ollamaUrlInput.value.trim();
+        if (!/^https?:\/\//i.test(url)) {
+            if (!url) {
+                log('Please enter a valid Ollama URL.', 'ERROR');
+                return;
+            }
+            url = `http://${url}`;
+            ui.ollamaUrlInput.value = url;
+            log('No scheme provided. Assuming http://', 'INFO');
+        }
         log('Fetching Ollama models...', 'API');
         ui.fetchOllamaModelsBtn.disabled = true;
         ui.ollamaModelSelector.disabled = true;


### PR DESCRIPTION
## Summary
- Validate and normalize the Ollama URL before listing models
- Warn on empty URL and default to http:// when no scheme is provided

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b36ebd06148329be4834c356144a63